### PR TITLE
Add a "Certification Authority Manager" role to allow for greater flexibility if needed 

### DIFF
--- a/app/controllers/cas_controller.rb
+++ b/app/controllers/cas_controller.rb
@@ -24,11 +24,13 @@ class CasController < ApplicationController
     action :show do
       allow :wisps_viewer
       allow :wisp_viewer, :of => :wisp
+      allow :ca_manager
     end
 
     action :crl do
       allow :wisps_manager
       allow :wisp_manager, :of => :wisp
+      allow :ca_manager
     end
   end
 

--- a/app/models/operator.rb
+++ b/app/models/operator.rb
@@ -43,7 +43,9 @@ class Operator < ActiveRecord::Base
       :access_points_custom_scripts_creator, :access_points_custom_scripts_manager,
       :access_points_custom_scripts_destroyer,
 
-      :servers_viewer, :servers_creator, :servers_manager, :servers_destroyer
+      :servers_viewer, :servers_creator, :servers_manager, :servers_destroyer,
+      
+      :ca_manager
   ]
 
   def roles

--- a/app/views/cas/show.html.erb
+++ b/app/views/cas/show.html.erb
@@ -29,7 +29,7 @@
     <h2><a href="#"><%= t(:General_infos) %></a></h2>
     <ul class="nav main">
       <li><%= link_to t(:Back), :back %></li>
-      <% if auth?(:wisps_manager) || auth?(:wisp_manager, @wisp) %>
+      <% if auth?(:wisps_manager) || auth?(:wisp_manager, @wisp) || auth?(:ca_manager) %>
           <li><%= link_to t(:Get_crl_list), wisp_ca_crl_path(@wisp) %></li>
       <% end %>
     </ul>
@@ -74,7 +74,7 @@
         <% @ca.x509_certificates.each do |cert| %>
             <tr>
               <td style="width:52px;">
-                <% if auth?(:wisps_manager) || auth?(:wisp_manager, @wisp) %>
+                <% if auth?(:wisps_manager) || auth?(:wisp_manager, @wisp) || auth?(:ca_manager) %>
                     <%= link_to image_tag("renew.png", :border=>0, :size => "16x16", :alt => t(:Renew_certificate)), renew_certificate_path(@wisp, cert),
                                 :title => t(:Renew_certificate),
                                 :confirm => t(:Are_you_sure_certificate_renew)


### PR DESCRIPTION
In some cases it would be useful to have a specific role that would allow an operator to deal with certificates renovation, revocation, ecc.

This patch allows an operator with the "ca_manager" role to manage all the certificates of the wisp to which he's associated to.
